### PR TITLE
Announce that tea is ready to all logged-in users

### DIFF
--- a/tea.sh
+++ b/tea.sh
@@ -31,3 +31,5 @@ commandpicker
 $player $tea_file &>/dev/null || \
 echo "We couldn't play your tea file." &>/dev/null
 echo "BUT YOUR TEA IS NOW READY, PUT THE MILK IN NOW!!!!"
+
+command -v wall >/dev/null 2>&1 && wall "tea.sh: Your tea is ready!"

--- a/tea.sh
+++ b/tea.sh
@@ -26,10 +26,19 @@ commandpicker() {
     fi
 }
 
+write_terminal() {
+    for u in $(who | grep "^${USER} " | awk '{print $1":"$2}'); do
+        a=$(echo "${u}" | cut -d: -f1,1)
+        b=$(echo "${u}" | cut -d: -f2,2)
+        echo $1 |write $a $b
+    done
+}
+
 commandpicker
 
 $player $tea_file &>/dev/null || \
 echo "We couldn't play your tea file." &>/dev/null
 echo "BUT YOUR TEA IS NOW READY, PUT THE MILK IN NOW!!!!"
 
-command -v wall >/dev/null 2>&1 && wall "tea.sh: Your tea is ready!"
+write_terminal "tea.sh: Your tea is ready!"
+


### PR DESCRIPTION
The `wall` command

    [...] displays  a message, or the contents of a file, or otherwise its standard input, on the terminals of all currently logged in
       users.  The command will wrap lines that are longer than 79 characters.  Short lines are whitespace padded to have 79  characters.
       The command will always put a carriage return and new line at the end of each line

(from the man page on `WALL(1)`)

I do a lot of work on the terminal, and thus it would be very helpful if I also got an alert that way. This line solves my all of my problems and more.

You can see how it looks here: http://imgur.com/a/OvarU